### PR TITLE
Fix path to module

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@tinymce/tinymce-jquery",
   "version": "2.0.1-rc",
   "description": "Official TinyMCE integration for jQuery",
-  "main": "dist/index.js",
+  "main": "dist/tinymce-jquery.js",
   "files": [
     "dist",
     "README.md",


### PR DESCRIPTION
The package currently references an incorrect path for the distribution module in package.json, this PR changes it to the correct path.